### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Version: 1.0.0
 
 - Yu-Cheng Lin  (androbugs.framework at gmail.com, @AndroBugs)
 
-## Steup Steps and Usage for Windows
+## Setup Steps and Usage for Windows
 
 **Easy to use for Android developers or hackers on Microsoft Windows: (a) No need to install Python 2.7 (b) No need to install any 3rd-party library (c) No need to install AndroBugs Framework**
 
@@ -29,8 +29,8 @@ Version: 1.0.0
 5. ```androbugs.exe -h```
 6. ```androbugs.exe -f [APK file]```
 
-## Massive Analysis Tool Steup Steps and Usage for Windows
-1. Complete the *Steup Steps and Usage for Windows* first
+## Massive Analysis Tool Setup Steps and Usage for Windows
+1. Complete the *Setup Steps and Usage for Windows* first
 2. Install the Windows version of MongoDB (https://www.mongodb.org/downloads)
 3. Install [PyMongo library](http://api.mongodb.org/python/current/installation.html)
 4. Config your own MongoDB settings: C:\AndroBugs_Framework\androbugs-db.cfg


### PR DESCRIPTION
## Summary
- replace incorrect "Steup Steps" with "Setup Steps" in README

## Testing
- `grep -n "Setup Steps" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_68463cab02b88324bfc938d3301177de