### PR TITLE
Fix minor typo in AndroBugs comment

### DIFF
--- a/androbugs.py
+++ b/androbugs.py
@@ -37,7 +37,7 @@ import sys
 
 	2.You need to install 'chilkat' component version in accordance with Python 2.7 first. This is for certificate checking.
 	  See the explanation of function 'def get_certificate(self, filename)' in 'apk.py' file
-	  => It becomes optional now. Since the related code is not comment out for ease of use and install.
+	  => It becomes optional now. Since the related code is not commented out for ease of use and install.
 
 	3.Use command 'grep -nFr "#Added by AndroBugs" *' to see what AndroBugs Framework has added to Androguard Open Source project under "tools/modified/androguard" root directory.
 


### PR DESCRIPTION
## Summary
- correct "not comment out" to "not commented out" in documentation comment

## Testing
- `python -m py_compile androbugs.py`

------
https://chatgpt.com/codex/tasks/task_e_68463daebac083248b5a2de36746ceb0